### PR TITLE
compatability fix for older compilers/standards

### DIFF
--- a/dnsperf.c
+++ b/dnsperf.c
@@ -997,12 +997,13 @@ static void set_thread_affinity(pthread_t thread, unsigned int num)
 {
    cpu_set_t cpus;
    unsigned int n, count;
+   int i;
 
    sched_getaffinity(0, sizeof(cpus), &cpus);
    count = CPU_COUNT(&cpus);
    n = num % count;
 
-   for (int i = 0; n >= 0; ++i) {
+   for (i = 0; n >= 0; ++i) {
        if (CPU_ISSET(i, &cpus)) {
            if (n-- == 0) {
                CPU_ZERO(&cpus);


### PR DESCRIPTION
When compiling with -std=gnu89 (or c89):

dnsperf.c: In function ‘set_thread_affinity’:
dnsperf.c:1014:4: error: ‘for’ loop initial declarations are only
allowed in C99 or C11 mode
    for (int i = 0; n >= 0; ++i) {